### PR TITLE
Updated URL of most recent blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MicroOpts
 Demonstration of JMH and micro-optimisations that can be used on a simple
 routine. but which can save a small amount of time.
 
-For the write-up, see https://alblue.bandlem.com/2020/02/16/class-getname.html
+For the write-up, see http://alblue.bandlem.com/2020/02/class-getname.html
 
 There is an older write-up at
 https://alblue.bandlem.com/2016/04/jmh-stringbuffer-stringbuilder.html which


### PR DESCRIPTION
The previous link gave a HTTP 404 Not Found error. I got the proposed new URL based on the previous URL, inferring the article name and searching within the blog.